### PR TITLE
Tell PHP about X-Forwarded-Proto

### DIFF
--- a/deploy/production/nginx-config.yaml
+++ b/deploy/production/nginx-config.yaml
@@ -21,6 +21,12 @@ data:
       gzip on;
       gzip_disable "msie6";
 
+      # Believe Cloudflare when it tells us we're on HTTPS
+      map $http_x_forwarded_proto $fastcgi_param_https {
+        default '';
+        https 'on';
+      }
+
       server {
         listen 80;
 
@@ -60,6 +66,7 @@ data:
           fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
           fastcgi_param PHP_VALUE "upload_max_filesize=64m
           post_max_size=64m";
+          fastcgi_param HTTPS $fastcgi_param_https;
           fastcgi_pass 127.0.0.1:9000;
         }
       }


### PR DESCRIPTION
PHP (rightly) thinks it's on an insecure connection, so all its URLs point to an insecure connection. This uses Cloudflare's `X-Forwarded-Proto` header to see what to use.